### PR TITLE
Add latest version of facebook WebDriver

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "php": ">=7.1.0",
         "ext-json": "*",
         "ext-zip": "*",
-        "facebook/webdriver": "^1.3",
+        "facebook/webdriver": "^1.7",
         "nesbot/carbon": "^1.20|^2.0",
         "illuminate/console": "~5.7.0|~5.8.0|~5.9.0",
         "illuminate/support": "~5.7.0|~5.8.0|~5.9.0",


### PR DESCRIPTION
Due to the latest version of the Chromedriver using W3C protocol by
default, this commit requires the latest version of
`facebook/webdriver`. The latest version forces the Chromedriver to not
use the W3C protocol by default.

This commit will fix issue #651.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
